### PR TITLE
Make this an installable Python module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/python/*.egg-info/
+/python/build/
+/python/dist/
 /target
 *.sqlite3*
 private*

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ linker = "aarch64-linux-android23-clang"
 cargo build -r --features build_extension --target aarch64-linux-android
 ```
 
+## As a Python "extension"
+
+If you want to use this project as an SQLite extension inside a Python project,
+you can install it as a Python package (you still need to have a rust compiler
+to actually build the binary):
+
+```bash
+pip install 'git+https://github.com/phiresky/sqlite-zstd.git#egg=sqlite_zstd&subdirectory=python'
+```
+
+This installs the extension as a Python package, with some support code to make
+it easy to use from Python code or [Datasette](https://datasette.io/).
+
 # Usage
 
 You can either load this library as SQLite extension or as a Rust library. Note that sqlite extensions are not persistent, so you need to load it each time you connect to the database.
@@ -203,6 +216,22 @@ conn.load_extension("libsqlite_zstd.so", None)?;
 ```
 
 See [here](https://docs.rs/rusqlite/0.24.2/rusqlite/struct.Connection.html#method.load_extension) for more information.
+
+**Python**
+
+If you have installed this as a Python module as described above, you can load
+the extension into an existion SQLite connection like this:
+
+```python
+import sqlite3
+import sqlite_zstd
+
+conn = sqlite3.connect(':memory:')
+sqlite_zstd.load(conn)
+```
+
+When using Datasette, this extension is loaded automatically into every
+connection.
 
 # Verbosity / Debugging
 

--- a/python/lib/__init__.py
+++ b/python/lib/__init__.py
@@ -1,0 +1,7 @@
+import sqlite3
+from importlib.resources import files, as_file
+
+def load(conn: sqlite3.Connection) -> None:
+    lib = next(x for x in files(__name__).iterdir() if x.name.startswith('lib'))
+    with as_file(lib) as ext:
+        conn.load_extension(str(ext))

--- a/python/lib/datasette.py
+++ b/python/lib/datasette.py
@@ -1,0 +1,9 @@
+from datasette import hookimpl
+from . import load
+
+
+@hookimpl
+def prepare_connection(conn):
+    conn.enable_load_extension(True)
+    load(conn)
+    conn.enable_load_extension(False)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.2", "setuptools_scm>=6.2", "setuptools_rust"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sqlite-zstd"
+requires-python = ">=3.9"
+dynamic = ["version"]
+
+[project.entry-points.datasette]
+sqlite_zstd = "sqlite_zstd.datasette"
+
+[tool.setuptools.package-dir]
+sqlite_zstd = "lib"
+
+[tool.setuptools_scm]
+root = ".."

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+from setuptools_rust import Binding, RustExtension
+
+setup(
+    rust_extensions=[RustExtension('sqlite_zstd.libsqlite_zstd',
+        path='../Cargo.toml',
+        binding=Binding.NoBinding,
+        features=['build_extension'],
+        py_limited_api=True,
+    )],
+)


### PR DESCRIPTION
This is based on ideas from @asg017 ([blog post](https://observablehq.com/@asg017/making-sqlite-extensions-pip-install-able), [pull request](https://github.com/asg017/sqlite-regex/pull/2)) extended with some of my own ideas:

- Use setuptools_rust to actually embed the cargo build into the python build
- Use `importlib.resources` to (maybe?) make it zip-safe (This is the only reason this requires 3.9)
- Embed the datasette plugin code, so this is available as a datasette plugin whenever both are installed
- Use setuptools_scm for automatic versioning which resemble the rust versions

All this combined means that `pip install 'git+https://github.com/TobiX/sqlite-zstd.git@python'` just works (if you have all the build tools installed, of course). Since this is now a pretty "standard" python build, building wheels should be simple by just following [setuptools_rust's documentation](https://setuptools-rust.readthedocs.io/en/latest/building_wheels.html)

Anyways, this is mostly a stupid proof-of-concept. Feel free to merge. Or not. I'm also open to improve this before merging (for example, adding CI integration)