### PR TITLE
Add rust lib option, update zstd, and extern rusqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ crate-type = ["lib", "cdylib"]
 
 #version = "0.11.2", features = ["experimental"]
 [dependencies]
-zstd = {version = "0.13.1"}
+zstd = {version = "0.13.1", features = ["experimental"]}
 #zstd = {version = "0.5.3", path="../zstd-rs"}
 #zstd = {version = "=0.5.4"}
 anyhow = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ structopt = {version = "0.3.23", optional = true}
 [dependencies.rusqlite]
 features = ["functions", "blob", "bundled", "array"]
 package = "rusqlite-le"
-version = "~0"
+version = "0.31.0"
 
 [dev-dependencies]
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ structopt = {version = "0.3.23", optional = true}
 
 [dependencies.rusqlite]
 features = ["functions", "blob", "bundled", "array"]
-package = "rusqlite-le"
+package = "rusqlite"
 version = "0.31.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ required-features = ["benchmark"]
 [lib]
 crate-type = ["lib", "cdylib"]
 
+#, features = ["experimental"]
 [dependencies]
-zstd = {version = "0.11.2", features = ["experimental"]}
+zstd = {version = "0.11.2"}
 #zstd = {version = "0.5.3", path="../zstd-rs"}
 #zstd = {version = "=0.5.4"}
 anyhow = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ structopt = {version = "0.3.23", optional = true}
 [dependencies.rusqlite]
 features = ["functions", "blob", "bundled", "array"]
 package = "rusqlite-le"
-version >= "0.24.2"
+version = "~0"
 
 [dev-dependencies]
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ required-features = ["benchmark"]
 [lib]
 crate-type = ["lib", "cdylib"]
 
-#, features = ["experimental"]
+#version = "0.11.2", features = ["experimental"]
 [dependencies]
-zstd = {version = "0.11.2"}
+zstd = {version = "0.13.1"}
 #zstd = {version = "0.5.3", path="../zstd-rs"}
 #zstd = {version = "=0.5.4"}
 anyhow = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ required-features = ["benchmark"]
 [lib]
 crate-type = ["lib", "cdylib"]
 
-#version = "0.11.2", features = ["experimental"]
 [dependencies]
 zstd = {version = "0.13.1", features = ["experimental"]}
 #zstd = {version = "0.5.3", path="../zstd-rs"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "create_test_db"
 required-features = ["benchmark"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 zstd = {version = "0.11.2", features = ["experimental"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ structopt = {version = "0.3.23", optional = true}
 [dependencies.rusqlite]
 features = ["functions", "blob", "bundled", "array"]
 package = "rusqlite-le"
-version = "0.24.2"
+version >= "0.24.2"
 
 [dev-dependencies]
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ structopt = {version = "0.3.23", optional = true}
 
 [dependencies.rusqlite]
 features = ["functions", "blob", "bundled", "array"]
-package = "rusqlite"
-version = "0.31.0"
+package = "rusqlite-le"
+version = "0.24.2"
 
 [dev-dependencies]
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ features = ["functions", "blob", "bundled", "array"]
 package = "rusqlite-le"
 version = "0.24.2"
 
+[patch.crates-io.rusqlite]
+features = ["functions", "blob", "bundled", "array"]
+git = "https://github.com/rusqlite/rusqlite.git"
+tag = "v0.31.0"
+
 [dev-dependencies]
 chrono = "0.4.19"
 names = "0.14.0"

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -89,7 +89,7 @@ fn zstd_compress_fn_tail<'a>(
     {
         // pledge source size (benchmarking shows this doesn't help any tho)
         let cctx = encoder.context_mut();
-        cctx.set_pledged_src_size(input_value.len() as u64)
+        cctx.set_pledged_src_size(Some(input_value.len() as u64))
             .map_err(|c| anyhow::anyhow!("setting pledged source size (code {c})"))?;
         // cctx.set_parameter(zstd::zstd_safe::CParameter::BlockDelimiters(false))
         //    .map_err(|_| anyhow::anyhow!("no"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::print_stdout)]
 
+pub extern crate rusqlite;
+
 use rusqlite::Connection;
 use util::init_logging;
 


### PR DESCRIPTION
Good Evening,

This PR edits the following:

1. Adds the "lib" flag to the "[lib]" section to make crate usable as a Cargo library
2. Updated the version of the "zstd" to fix a bug in version "0.11.2" (see below for details)
3. Wrapped a parameter with "Some()" to make compatible with updated zstd API
4. Added an "pub extern crate rusqlite" to help resolve compilation issues

Most of these changes are based on existing issues and issues that I also encountered with the current 3.2.0 release. The zstd error I was running into was:

```
error[E0432]: unresolved import `zstd_sys::ZSTD_cParameter::ZSTD_c_experimentalParam6`
   --> <USER>/.cargo/registry/src/index.crates.io-6f17d22bba15001f/zstd-safe-5.0.2+zstd.1.5.2/src/lib.rs:467:13
    |
467 |             ZSTD_c_experimentalParam6 as ZSTD_c_targetCBlockSize,
    |             -------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |             |
    |             no `ZSTD_c_experimentalParam6` in `ZSTD_cParameter`
    |             help: a similar name exists in the module: `ZSTD_c_experimentalParam1`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `zstd-safe` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

Feel free to suggest any edits to this patch. Thanks!