### PR TITLE
Mention that the sample of zstd_train_dict is chosen randomly

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ Note that a compression VFS such as https://github.com/mlin/sqlite_zstd_vfs migh
 
 - `zstd_train_dict(agg, dict_size: int, sample_count: int) -> blob`
 
-  Aggregate function (like sum() or count()) to train a zstd dictionary on sample_count samples of the given aggregate data
+  Aggregate function (like sum() or count()) to train a zstd dictionary on randomly selected sample_count samples of the given aggregate data
 
-  Example use: `select zstd_train_dict(tbl.data, 100000, 1000) from tbl` will return a dictionary of size 100kB trained on 1000 samples in `tbl`
+  Example use: `select zstd_train_dict(tbl.data, 100000, 1000) from tbl` will return a dictionary of size 100kB trained on 1000 random samples in `tbl`
 
   The recommended number of samples is 100x the target dictionary size. As an example, you can train a dict of 100kB with the "optimal" sample count as follows:
 


### PR DESCRIPTION
Thanks for maintaining this project.

When looking at the documentation, I wasn't sure if the samples in zstd_train_dict are randomly selected or if only the first sample_count of samples are selected. After checking [the implementation](https://github.com/phiresky/sqlite-zstd/blob/3a820f34f326a2d177292071af42104d2634316c/src/dict_training.rs#L52-L65), I found that the samples are selected randomly. I believe this might be useful information for others as well, so I added the relevant information to the documentation.